### PR TITLE
Remove explicit promises from AllAvailable.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3185,8 +3185,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3207,14 +3206,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3229,20 +3226,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3359,8 +3353,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3372,7 +3365,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3387,7 +3379,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3395,14 +3386,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3421,7 +3410,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3502,8 +3490,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3515,7 +3502,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3601,8 +3587,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3638,7 +3623,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3658,7 +3642,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3702,14 +3685,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/service-worker.ts
+++ b/service-worker.ts
@@ -31,6 +31,20 @@ workbox.routing.registerRoute(
   })
 );
 
+workbox.precaching.precacheAndRoute([
+    '/find.html',
+    '/find.css',
+    '/index.html',
+    '/choose.html',
+    '/images/favorite.png',
+    '/images/reviewed.png',
+    '/images/BackArrow.png',
+    '/images/NextArrow.png',
+    '/book.js',
+    '/site.css',
+
+]);
+
 workbox.routing.registerRoute(/.\/content\/index\/AllAvailable$/, async () => {
   let ids = getAllAvailableIDs();
   return new Response(await ids);

--- a/service-worker.ts
+++ b/service-worker.ts
@@ -59,30 +59,32 @@ async function getAllAvailableIDs(): Promise<string> {
 
   // Offline case.
   let ids: string = "";
-  return new Promise((resolve, reject) => {
-    caches.open("html-cache").then(cache => {
-      cache.keys().then(keys => {
-        if (keys.length == 0) {
-          resolve("");
-        }
 
-        keys.forEach((request, index, array) => {
-          let url = request.url;
-          if (!url.includes("content")) {
-            return;
-          }
-          let tokens = url
-            .substring(url.search("content") + "content".length)
-            .split("/");
-          if (!tokens[tokens.length - 1].match(/\d.html/)) {
-            return;
-          }
-          let id = tokens.join("");
-          id = id.substring(0, id.length - 5);
-          ids += id;
-        });
-        resolve(ids);
-      });
-    });
+  let cache = await caches.open("html-cache");
+  let keys = await cache.keys();
+
+  if (keys.length == 0) {
+    return "";
+  }
+
+  keys.forEach((request, index, array) => {
+    let url = request.url;
+    if (!url.includes("content")) {
+      return;
+    }
+
+    let tokens = url
+        .substring(url.search("content") + "content".length)
+        .split("/");
+
+    if (!tokens[tokens.length -1].match(/\d.html/)){
+      return;
+    }
+
+    let id = tokens.join("");
+    id = id.substring(0, id.length - 5);
+    ids += id;
   });
+
+  return ids;
 }


### PR DESCRIPTION
Small PR. 

Because the AllAvailable fetch function is already async, manually crafting promises is unnecessary.